### PR TITLE
Remove wrong RepositoryUrl property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,7 +17,6 @@
     <RepositoryUrl>https://github.com/nodatime/nodatime.serialization</RepositoryUrl>
     <PackageProjectUrl>https://nodatime.org/</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/nodatime/nodatime</RepositoryUrl>
     <Authors>The Noda Time authors</Authors>
 
     <!-- Properties to get SourceLink to work -->


### PR DESCRIPTION
There were two `RepositoryUrl` properties, one with the correct value (`https://github.com/nodatime/nodatime.serialization`) and one with a wrong value (`https://github.com/nodatime/nodatime`).

Unfortunately, the one with the wrong value was picked when creating the NuGet package, making it difficult to find the release notes from the [NuGet page](https://www.nuget.org/packages/NodaTime.Serialization.SystemTextJson) that was pointing to the wrong _Source repository_.